### PR TITLE
Make schema inference an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Create a `config.json` file with connection details to snowflake.
                 "delimiter": ",",
                 "encoding": "utf-8",
                 "sanitize_header": false,
-                "skip_rows": 0
+                "skip_rows": 0,
+                "infer_schema": false,
             }
         ],
         "xml_fields": [],
@@ -79,6 +80,7 @@ Create a `config.json` file with connection details to snowflake.
    - `encoding`: File encoding, defaults to `utf-8`
    - `sanitize_header`: Boolean, specifies whether to clean up header names so that they are more likely to be accepted by a target SQL database
    - `skip_rows`: Integer, specifies the number of rows to skip at the top of the file to handle non-data content like comments or other text. Default 0.
+   - `infer_schema`: Boolean. If set to true (the default value), the tap will attempt to detect the data type of the fields. Otherwise all fields will be treated as strings.
 
 ## Discovery mode:
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -44,7 +44,8 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
             'sanitize_header': table_spec.get('sanitize_header', False),
-            'skip_rows': table_spec.get('skip_rows', 0)}
+            'skip_rows': table_spec.get('skip_rows', 0),
+            'infer_schema': table_spec.get('infer_schema', True)}
 
     csv_data = file_handle
     if file_handle.name.endswith('.xml'):
@@ -183,7 +184,7 @@ def generate_schema(samples, table_spec):
 
     schema = {}
     for key, value in type_summary.items():
-        datatype = pick_datatype(value)
+        datatype = pick_datatype(value) if table_spec['infer_schema'] else 'string'
 
         if datatype == 'date-time':
             schema[key] = {


### PR DESCRIPTION
### What was done

Add the option to bypass the schema inference done [here](https://github.com/Shopify/tap-sftp-xml-support/blob/aa8b1fe11de5ddc162bd82dc17013ecaec50cda3/tap_sftp/singer_encodings/json_schema.py#L152C1-L176C21).

I'm adding this as an optional table setting – leaving the default set to `true`. This means no change from the previous behavior unless it's explicitly set to `false`.

### Context

I've seen some cases where the schema inference doesn't work well. It's easy enough to make it optional & it gives us the ability to opt out. When we opt out of the schema inference, fields will simply be treated as strings.

If we're using this tap in a Meltano context, that's where we would configure it be adding this to the tap configuration:

```infer_schema: false```

### Testing

To test in a Meltano context, simply clone this branch & point to this repo in your Meltano configuration `pip_url` with the `-e` (executable) flag:

```pip_url: -e /Users/<your-username>/src/github.com/Shopify/tap-sftp-xml-support```

