### PR TITLE
Ensure we have a default value for the infer_schema setting

### DIFF
--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -184,7 +184,7 @@ def generate_schema(samples, table_spec):
 
     schema = {}
     for key, value in type_summary.items():
-        datatype = pick_datatype(value) if table_spec['infer_schema'] else 'string'
+        datatype = pick_datatype(value) if table_spec.get('infer_schema', True) else 'string'
 
         if datatype == 'date-time':
             schema[key] = {

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -66,7 +66,8 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
             'file_name': sftp_file_spec['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
             'sanitize_header': table_spec.get('sanitize_header', False),
-            'skip_rows': table_spec.get('skip_rows', False)}
+            'skip_rows': table_spec.get('skip_rows', False),
+            'infer_schema': table_spec.get('infer_schema', True)}
 
     csv_data = file_handle
     if file_handle.name.endswith('.xml'):


### PR DESCRIPTION
Quick follow-up on: https://github.com/Shopify/tap-sftp-xml-support/pull/2

Following the previous update, I noticed the tap would break if using the `--discovery` flag. This change simply ensures that we always have a default value of `True` for the `infer_schema` setting.

Tested in Meltano context using `meltano invoke <tap-name> --discover`