### PR TITLE
Retry on `SSHException` errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 singer-python==5.9.0
-paramiko==3.4.0
+paramiko==3.5.0
 backoff==1.8.0
 terminaltables==3.1.0
 python-gnupg==0.4.6

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -59,18 +59,10 @@ class SFTPConnection():
             self.transport.connect(username=self.username, password=self.password, hostkey=None, pkey=self.key)
             self.__sftp = paramiko.SFTPClient.from_transport(self.transport)
         except (AuthenticationException, SSHException) as ex:
-<<<<<<< HEAD
-            self.transport.close()
-            self.transport = paramiko.Transport((self.host, self.port))
-            self.transport.use_compression(True)
-            self.transport.connect(username=self.username, password=self.password, hostkey=None, pkey=None)
-            self.__sftp = paramiko.SFTPClient.from_transport(self.transport)
-=======
             LOGGER.warning('Connection attempt failed: %s', ex)
             if self.transport is not None:
                 self.transport.close()
             raise
->>>>>>> c0efbf7 (Retry on SSHExceptions)
 
     @property
     def sftp(self):

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -38,12 +38,12 @@ class SFTPConnection():
 
         self.__connect()
 
-    # If connection is snapped during connect flow, retry up to a
-    # minute for SSH connection to succeed. 2^6 + 2^5 + ...
+    # If connection is snapped during connect flow, retry up to two
+    # minutes for SSH connection to succeed. 2^7 + 2^6 + ...
     @backoff.on_exception(
         backoff.expo,
         (EOFError, SSHException),
-        max_tries=6,
+        max_tries=7,
         on_backoff=handle_backoff,
         jitter=None,
         factor=2)


### PR DESCRIPTION
### Issue

Starting Sept 12 we've been seeing intermittent issues connecting to Impact Radius FTP server, see this issue: https://github.com/Shopify/growth-paid-data-extractors/issues/356

I suspect this has to do with their server configuration and I opened a support ticket with their team. In the meantime, I think we would benefit from better retry logic in the tap itself.

### What was done

The changes included here are:

- Bump the [paramiko lib](https://github.com/paramiko/paramiko) to its latest version.
- Configure the retry with backoff to retry for up to two minutes on `SSHExceptions`.

### Testing

I tested this locally with our Meltano setup.

- Updated [this line](https://github.com/Shopify/growth-paid-data-extractors/blob/main/subconfigs/extractors/tap-sftp.meltano.yml#L5) to point to my local version of the tap: `pip_url: -e /Users/<your-user-name>/src/github.com/Shopify/tap-sftp-xml-support`
- `meltano install`
- `meltano run tap-sftp-impact-radius target-jsonl`

I could see we retried a few times & then succeeded to connect and pull the files.