### PR TITLE
Better logic for updating the modified_since bookmark

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -142,8 +142,9 @@ class SFTPConnection():
 
         for f in matching_files:
             LOGGER.info("Found file: %s", f['filepath'])
-
+    
         if modified_since is not None:
+            LOGGER.info("Processing files modified since: %s", modified_since)
             matching_files = [f for f in matching_files if f["last_modified"] > modified_since]
 
         return matching_files

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -146,7 +146,8 @@ class SFTPConnection():
         if modified_since is not None:
             LOGGER.info("Processing files modified since: %s", modified_since)
             matching_files = [f for f in matching_files if f["last_modified"] > modified_since]
-
+        
+        matching_files = sorted(matching_files, key=lambda x: x["last_modified"], reverse=True)
         return matching_files
 
     def get_file_handle(self, f, decryption_configs=None):

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -147,7 +147,7 @@ class SFTPConnection():
             LOGGER.info("Processing files modified since: %s", modified_since)
             matching_files = [f for f in matching_files if f["last_modified"] > modified_since]
         
-        matching_files = sorted(matching_files, key=lambda x: x["last_modified"], reverse=True)
+        matching_files = sorted(matching_files, key=lambda x: x["last_modified"])
         return matching_files
 
     def get_file_handle(self, f, decryption_configs=None):

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -49,6 +49,7 @@ def sync_stream(config, state, stream, sftp_client):
     if latest_modified > modified_since:
         state = singer.write_bookmark(state, table_name, 'modified_since', latest_modified.isoformat())
         singer.write_state(state)
+        LOGGER.info('Updated bookmark to %s', latest_modified.isoformat())
 
     LOGGER.info('Wrote %s records for table "%s".', records_streamed, table_name)
 

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -44,8 +44,11 @@ def sync_stream(config, state, stream, sftp_client):
         records_streamed += sync_file(sftp_file, stream, table_spec, config, sftp_client)
         if sftp_file['last_modified'] > latest_modified:
             latest_modified = sftp_file['last_modified']
-            state = singer.write_bookmark(state, table_name, 'modified_since', latest_modified.isoformat())
-            singer.write_state(state)
+
+    # Update bookmark only once, after processing all files
+    if latest_modified > modified_since:
+        state = singer.write_bookmark(state, table_name, 'modified_since', latest_modified.isoformat())
+        singer.write_state(state)
 
     LOGGER.info('Wrote %s records for table "%s".', records_streamed, table_name)
 

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -39,17 +39,12 @@ def sync_stream(config, state, stream, sftp_client):
     if not files:
         return records_streamed
 
-    latest_modified = modified_since
     for sftp_file in files:
         records_streamed += sync_file(sftp_file, stream, table_spec, config, sftp_client)
-        if sftp_file['last_modified'] > latest_modified:
-            latest_modified = sftp_file['last_modified']
-
-    # Update bookmark only once, after processing all files
-    if latest_modified > modified_since:
-        state = singer.write_bookmark(state, table_name, 'modified_since', latest_modified.isoformat())
+        last_modified = sftp_file['last_modified'].isoformat()
+        state = singer.write_bookmark(state, table_name, 'modified_since', last_modified)
         singer.write_state(state)
-        LOGGER.info('Updated bookmark to %s', latest_modified.isoformat())
+        LOGGER.info('Updated bookmark to %s', last_modified)        
 
     LOGGER.info('Wrote %s records for table "%s".', records_streamed, table_name)
 


### PR DESCRIPTION
### Context

Between job runs, this extractor keeps track of its position in the history of files processed via a state bookmark. It looks like this:

```{"completed": {"singer_state": {"bookmarks": {"Conversions": {"modified_since": "2024-09-13T12:01:03+00:00"}}}}, "partial": {}}```

In this example, `Conversions` is the stream name. The `modified_since` field is updated when we finish syncing a file – using its `last_modified` attribute. This is meant to ensure we don't reprocess files in a subsequent run and only process new files.

### Issue

This is an issue that only happens when for some reason we fail to process files daily and we need to process files from a few different days.

With the previous code version, there is a bug. We are not guaranteed to process the files in order. Thus we can have:

- A file last modified on Sept 15 --> bookmark is updated to Sept 15
- A file last modified on Sept 17 --> bookmark is updated to Sept 17
- A file last modified on Sept 14 --> bookmark is updated to Sept 14

If the last file is the last one to be processed, our state will keep Sept 14 as its `modified_since` date – which is incorrect since we have processed files up to Sept 17. 

### Solution

- Order the files by their `last_modified` attribute before processing them.
- Add some logging to make it easier to follow what the extractor is doing.

### Testing

I saw the issue live as we needed to process a few days of data after an extractor failure due to https://github.com/Shopify/growth-paid-data-extractors/issues/356.

I reproduced the issue locally & saw the same:

- Files are not processed in order.
- State is updated in a non-linear way (as in the example above)/

I tested these changes via our meltano setup in:

- Updated [this line](https://github.com/Shopify/growth-paid-data-extractors/blob/main/subconfigs/extractors/tap-sftp.meltano.yml#L5) to point to my local version of the tap: pip_url: -e /Users/<your-user-name>/src/github.com/Shopify/tap-sftp-xml-support
- `meltano install`
- `meltano run tap-sftp-impact-radius target-jsonl` 

I confirmed via some logging that:

- The files are ordered correctly, from earliest to latest.
- The files are processed in order & the state is updated after each file is processed.