### PR TITLE
Log file paths after files have been filtered

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -139,13 +139,13 @@ class SFTPConnection():
             LOGGER.info('Found %s files in "%s" matching "%s"', len(matching_files), prefix, search_pattern)
         else:
             LOGGER.warning('Found no files on specified SFTP server at "%s" matching "%s"', prefix, search_pattern)
-
-        for f in matching_files:
-            LOGGER.info("Found file: %s", f['filepath'])
     
         if modified_since is not None:
             LOGGER.info("Processing files modified since: %s", modified_since)
             matching_files = [f for f in matching_files if f["last_modified"] > modified_since]
+
+        for f in matching_files:
+            LOGGER.info("Found file: %s", f['filepath'])
         
         matching_files = sorted(matching_files, key=lambda x: x["last_modified"])
         return matching_files


### PR DESCRIPTION
Very small change to log the files that will be processed **after** filtering them. Logging all the files found in the FTP server is unhelpful & noisy.

I'll ship this without review since it's a very small change with no risk that makes our logs much more useful.