### PR TITLE
Increase SFTP connection timeout

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -62,7 +62,7 @@ class SFTPConnection():
                 password=self.password,
                 pkey=self.key,
                 compress=True,
-                timeout=60
+                timeout=120
             )
             self.sftp = ssh_client.open_sftp()
         except (AuthenticationException, SSHException) as ex:


### PR DESCRIPTION
I'm bumping the timeout to connect to the SFTP server to 120 seconds as was suggested by the Impact Radius team. See [this comment](https://github.com/Shopify/growth-paid-data-extractors/issues/356#issuecomment-2385397962) for more details.

This should prevent some intermittent errors we've been seeing in our logs when the extractor fails to properly connect to the server.